### PR TITLE
複数アノテーションを付与した際に改行されず1行にまとまってしまう整形ルールを修正

### DIFF
--- a/eclipse/java-format-setting.xml
+++ b/eclipse/java-format-setting.xml
@@ -34,13 +34,5 @@
 <!-- おそらく他にも alignment_for_ 系で差異がある -->
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<!-- 4.18 で導入されたアノテーションの改行設定。昔の挙動相当に設定する -->
-<!-- https://www.eclipse.org/eclipse/news/4.18/jdt.php#formatter-wrap-annotations -->
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_enum_constant" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="48"/>
 </profile>
 </profiles>


### PR DESCRIPTION
closes #1
